### PR TITLE
doc: Add doi links to paper/ preprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 For a high-level introduction, please refer to the following manuscripts: 
 
-[msemalign: A pipeline for serial section multibeam scanning electron microscopy volume alignment](xxx)  
+[msemalign: A pipeline for serial section multibeam scanning electron microscopy volume alignment](https://doi.org/10.3389/fnins.2023.1281098)  
 &nbsp;&nbsp;&nbsp;&nbsp;Describes the 2D and 3D alignment of petabyte-scale ssmSEM datasets  
-[GAUSS-EM: Guided accumulation of ultrathin serial sections with a static magnetic field for volume electron microscopy](xxx)  
+[GAUSS-EM: Guided accumulation of ultrathin serial sections with a static magnetic field for volume electron microscopy](https://doi.org/10.1101/2023.11.13.566828 )  
 &nbsp;&nbsp;&nbsp;&nbsp;Describes the volume sectioning and also the section order solving methodology
 
 ## Installation / Dependencies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For a high-level introduction, please refer to the following manuscripts:
 
 [msemalign: A pipeline for serial section multibeam scanning electron microscopy volume alignment](https://doi.org/10.3389/fnins.2023.1281098)  
 &nbsp;&nbsp;&nbsp;&nbsp;Describes the 2D and 3D alignment of petabyte-scale ssmSEM datasets  
-[GAUSS-EM: Guided accumulation of ultrathin serial sections with a static magnetic field for volume electron microscopy](https://doi.org/10.1101/2023.11.13.566828 )  
+[GAUSS-EM: Guided accumulation of ultrathin serial sections with a static magnetic field for volume electron microscopy](https://doi.org/10.1016/j.crmeth.2024.100720)  
 &nbsp;&nbsp;&nbsp;&nbsp;Describes the volume sectioning and also the section order solving methodology
 
 ## Installation / Dependencies


### PR DESCRIPTION
Just noticed that the main links are not set (yet).
* the msemalign link now points to the peer-reviewed publication
* the gaussEM link points to the biorxiv pre-print